### PR TITLE
fix unit test for cat/stack

### DIFF
--- a/tests/test_cplx.py
+++ b/tests/test_cplx.py
@@ -541,7 +541,7 @@ def test_cat_stack(random_state):
     ]
 
     for n in [0, 1, 2]:
-        with pytest.raises(RuntimeError, match="Sizes of tensors must match"):
+        with pytest.raises(RuntimeError, match="expects each tensor to be equal size"):
             cplx.stack(map(cplx.Cplx.from_numpy, np_tensors), dim=n)
 
     with pytest.raises(RuntimeError, match="Sizes of tensors must match"):


### PR DESCRIPTION
Tested with pytorch-1.6.0+cpu

Previously failed with:
```
$ pytest tests/test_cplx.py
===================================================================== test session starts =====================================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/schroeter/github/cplxmodule
collected 22 items

tests/test_cplx.py .................F.sss                                                                                                               [100%]

========================================================================== FAILURES ===========================================================================
_______________________________________________________________________ test_cat_stack ________________________________________________________________________

random_state = RandomState(MT19937) at 0x7F1613876E40

    def test_cat_stack(random_state):
        with pytest.raises(RuntimeError, match="a non-empty"):
            cplx.stack([], dim=0)

        np_tensors = 10 * [
            random_state.randn(5, 3, 7) + 1j * random_state.randn(5, 3, 7)
        ]
        tr_tensors = [*map(cplx.Cplx.from_numpy, np_tensors)]

        for n in [0, 1, 2]:
            assert_allclose(cplx.cat(tr_tensors, dim=n).numpy(),
                            np.concatenate(np_tensors, axis=n))

        for n in [0, 1, 2, 3]:
            assert_allclose(cplx.stack(tr_tensors, dim=n).numpy(),
                            np.stack(np_tensors, axis=n))

        np_tensors = [
            random_state.randn(3, 7) + 1j * random_state.randn(3, 7),
            random_state.randn(5, 7) + 1j * random_state.randn(5, 7),
        ]

        for n in [0, 1, 2]:
            with pytest.raises(RuntimeError, match="Sizes of tensors must match"):
>               cplx.stack(map(cplx.Cplx.from_numpy, np_tensors), dim=n)

tests/test_cplx.py:545:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

tensors = [Cplx(
  real=tensor([[ 1.4759, -0.2692, -0.5115,  0.1719, -0.4836, -3.0965, -0.4236],
        [-0.9939,  0.5774, -1.9...333,  0.9406],
        [-0.8170, -0.6743, -1.1605,  1.1426, -1.8694,  0.5829,  1.6829]],
       dtype=torch.float64)
)]
dim = 0

    def stack(tensors, dim):
        tensors = [*map(Cplx, tensors)]
>       return Cplx(torch.stack([z.real for z in tensors], dim=dim),
                    torch.stack([z.imag for z in tensors], dim=dim))
E       RuntimeError: stack expects each tensor to be equal size, but got [3, 7] at entry 0 and [5, 7] at entry 1

../../.virtualenvs/pytorch-1.5/lib/python3.8/site-packages/cplxmodule/cplx.py:372: RuntimeError

During handling of the above exception, another exception occurred:

random_state = RandomState(MT19937) at 0x7F1613876E40

    def test_cat_stack(random_state):
        with pytest.raises(RuntimeError, match="a non-empty"):
            cplx.stack([], dim=0)

        np_tensors = 10 * [
            random_state.randn(5, 3, 7) + 1j * random_state.randn(5, 3, 7)
        ]
        tr_tensors = [*map(cplx.Cplx.from_numpy, np_tensors)]

        for n in [0, 1, 2]:
            assert_allclose(cplx.cat(tr_tensors, dim=n).numpy(),
                            np.concatenate(np_tensors, axis=n))

        for n in [0, 1, 2, 3]:
            assert_allclose(cplx.stack(tr_tensors, dim=n).numpy(),
                            np.stack(np_tensors, axis=n))

        np_tensors = [
            random_state.randn(3, 7) + 1j * random_state.randn(3, 7),
            random_state.randn(5, 7) + 1j * random_state.randn(5, 7),
        ]

        for n in [0, 1, 2]:
            with pytest.raises(RuntimeError, match="Sizes of tensors must match"):
>               cplx.stack(map(cplx.Cplx.from_numpy, np_tensors), dim=n)
E               AssertionError: Regex pattern 'Sizes of tensors must match' does not match 'stack expects each tensor to be equal size, but got [3, 7] at entry 0 and [5, 7] at entry 1'.

tests/test_cplx.py:545: AssertionError
====================================================================== warnings summary =======================================================================
tests/test_cplx.py::test_conv1d_transform
  /home/schroeter/.virtualenvs/pytorch-1.5/lib/python3.8/site-packages/cplxmodule/cplx.py:257: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:141.)
    im = torch.from_numpy(numpy.imag)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=================================================================== short test summary info ===================================================================
FAILED tests/test_cplx.py::test_cat_stack - AssertionError: Regex pattern 'Sizes of tensors must match' does not match 'stack expects each tensor to be equa...
===================================================== 1 failed, 18 passed, 3 skipped, 1 warning in 4.97s ======================================================

```